### PR TITLE
Add Streamlit PID simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# PID-Control
+# PID Control Project
+
+This project demonstrates a simple PID controller applied to a second-order system using a Streamlit web interface. Users can adjust controller parameters interactively and visualize both servo and regulatory responses. The application also provides basic pole placement and stability information.
+
+## Requirements
+
+```
+pip install streamlit control
+```
+
+## Running
+
+Execute the Streamlit app from the repository root:
+
+```
+streamlit run pid_app/streamlit_app.py
+```
+
+This will open a browser window showing widgets for tuning parameters and plotting the response.

--- a/pid_app/__init__.py
+++ b/pid_app/__init__.py
@@ -1,0 +1,1 @@
+"""PID controller app"""

--- a/pid_app/pid.py
+++ b/pid_app/pid.py
@@ -1,0 +1,20 @@
+class PIDController:
+    """Simple PID controller"""
+
+    def __init__(self, kp=1.0, ki=0.0, kd=0.0):
+        self.kp = kp
+        self.ki = ki
+        self.kd = kd
+        self.integral = 0.0
+        self.prev_error = 0.0
+
+    def reset(self):
+        self.integral = 0.0
+        self.prev_error = 0.0
+
+    def update(self, error, dt):
+        """Return control action for a given error and timestep"""
+        self.integral += error * dt
+        derivative = (error - self.prev_error) / dt if dt > 0 else 0.0
+        self.prev_error = error
+        return self.kp * error + self.ki * self.integral + self.kd * derivative

--- a/pid_app/plant.py
+++ b/pid_app/plant.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+import numpy as np
+from control import TransferFunction, forced_response
+
+
+def second_order_system(wn: float, zeta: float) -> TransferFunction:
+    """Return a second-order TransferFunction"""
+    num = [1.0]
+    den = [1.0, 2 * zeta * wn, wn ** 2]
+    return TransferFunction(num, den)
+
+
+@dataclass
+class SimulationResult:
+    time: np.ndarray
+    output: np.ndarray
+
+
+def simulate_closed_loop(pid, wn: float, zeta: float, t_end: float = 10.0, n: int = 500):
+    plant = second_order_system(wn, zeta)
+    # closed-loop transfer function for servo control: C*G/(1+C*G)
+    C = TransferFunction([pid.kd, pid.kp, pid.ki], [1, 0])
+    closed_loop = (C * plant).feedback(1)
+    t = np.linspace(0, t_end, n)
+    t, y = forced_response(closed_loop, T=t)
+    return SimulationResult(t, y)
+
+
+def simulate_disturbance(pid, wn: float, zeta: float, t_end: float = 10.0, n: int = 500):
+    plant = second_order_system(wn, zeta)
+    C = TransferFunction([pid.kd, pid.kp, pid.ki], [1, 0])
+    # output due to load disturbance at plant input: G/(1+C*G)
+    disturbance_tf = plant.feedback(C)
+    t = np.linspace(0, t_end, n)
+    t, y = forced_response(disturbance_tf, T=t)
+    return SimulationResult(t, y)

--- a/pid_app/streamlit_app.py
+++ b/pid_app/streamlit_app.py
@@ -1,0 +1,79 @@
+import ast
+import streamlit as st
+import numpy as np
+import matplotlib.pyplot as plt
+from control import TransferFunction, forced_response, pole
+
+from .pid import PIDController
+from .plant import second_order_system, simulate_closed_loop, simulate_disturbance
+
+
+st.set_page_config(page_title="PID Second Order Simulator")
+
+st.title("PID Controller Simulator")
+
+with st.sidebar:
+    st.header("Plant Parameters")
+    wn = st.number_input("Natural frequency ωn", value=1.0, min_value=0.1)
+    zeta = st.slider("Damping ratio ζ", 0.0, 2.0, value=0.2)
+
+    st.header("Tuning")
+    tuning_mode = st.selectbox("Mode", ["Manual", "Ziegler-Nichols"], index=0)
+    if tuning_mode == "Manual":
+        kp = st.number_input("Kp", value=1.0)
+        ki = st.number_input("Ki", value=0.0)
+        kd = st.number_input("Kd", value=0.0)
+    else:
+        ku = st.number_input("Ultimate gain Ku", value=1.0)
+        tu = st.number_input("Ultimate period Tu", value=1.0)
+        kp = 0.6 * ku
+        ki = 2 * kp / tu
+        kd = kp * tu / 8
+        st.write(f"Kp={kp:.3f}, Ki={ki:.3f}, Kd={kd:.3f}")
+
+    pid = PIDController(kp, ki, kd)
+
+    st.header("Pole Placement")
+    p1 = st.text_input("Pole p1", value="-1.0")
+    p2 = st.text_input("Pole p2", value="-1.0+1j")
+    p3 = st.text_input("Pole p3", value="-1.0-1j")
+    if st.button("Compute PID for poles"):
+        try:
+            poles = [complex(ast.literal_eval(p)) for p in (p1, p2, p3)]
+            coeffs = np.poly(poles)
+            a = 2 * zeta * wn
+            b = wn ** 2
+            pid.kd = coeffs[1] - a
+            pid.kp = coeffs[2] - b
+            pid.ki = coeffs[3]
+            st.success(f"PID set to Kp={pid.kp:.3f}, Ki={pid.ki:.3f}, Kd={pid.kd:.3f}")
+        except Exception as exc:
+            st.error(f"Failed to compute PID: {exc}")
+
+
+st.subheader("Servo Control Response")
+servo = simulate_closed_loop(pid, wn, zeta)
+fig1, ax1 = plt.subplots()
+ax1.plot(servo.time, servo.output)
+ax1.set_xlabel("Time [s]")
+ax1.set_ylabel("Output")
+ax1.grid(True)
+st.pyplot(fig1)
+
+st.subheader("Regulatory Control Response (Load Disturbance)")
+reg = simulate_disturbance(pid, wn, zeta)
+fig2, ax2 = plt.subplots()
+ax2.plot(reg.time, reg.output)
+ax2.set_xlabel("Time [s]")
+ax2.set_ylabel("Output")
+ax2.grid(True)
+st.pyplot(fig2)
+
+# Stability analysis
+st.subheader("Closed-loop Poles")
+C = TransferFunction([pid.kd, pid.kp, pid.ki], [1, 0])
+plant = second_order_system(wn, zeta)
+cl = (C * plant).feedback(1)
+cl_poles = pole(cl)
+st.write(cl_poles)
+


### PR DESCRIPTION
## Summary
- add simple PID controller implementation
- create second-order plant model and simulation helpers
- build Streamlit app with widgets for tuning and pole placement
- document how to run the Streamlit interface

## Testing
- `pip install streamlit control`
- `streamlit run pid_app/streamlit_app.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_683f7a55f940832bb8d230a98f2be981